### PR TITLE
Add Quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Launch the debugger and in the browser, navigate to `http://localhost:5000/api/d
 You now have a way to query the info for the Hello resource aswell as a way to discover the Hello resource.
 ## Reference
 
-### Supported Classes
+### API Resources and the Hydra Class
 
 To describe a Hydra Supported Class, decorate the model type that represents a resource with the `[SupportedClass]` attribute. Describe the supported properties with the `[SupportedProperty]` attribute.
 
@@ -482,7 +482,7 @@ public class Stock
     public double CurrentPrice { get; }
 }
 ```
-### Supported Collections
+### API Collections and the Hydra Collection
 
 To describe a Hydra Supported Collection, decorate the model type that represents an item in the collection with the `[SupportedCollection]` attribute.
 
@@ -494,7 +494,7 @@ public class Stock
     // Class code here
 }
 ```
-### Supported Operations
+### API Operations and the Hydra Operation
 
 To describe Hydra Supported Operations, decorate the controller method that represents the operation with the  `[Operation]` attribute.
 
@@ -514,7 +514,7 @@ public class StocksController
     }
 }
 ```
-### Api Documentation
+### API Documentation and the Hydra ApiDocumentation
 
 The `ApiDocumentation` class is the central documentation source for a Hydra Web API. Add your supported classes to it via the `AddSupportedClass<T>()` method.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,100 @@ Hydra.NET is a simple library for .NET that provides building blocks for creatin
 
 ## Quickstart
 
+This quickstart will show you how to create a basic ASP.NET Hydra Service using the .NET 5 SDK and VS Code.
+
+### Overview 
+
+This tutorial creates the following API:
+| Resource | Operation                       | Description                              |
+|----------|---------------------------------|------------------------------------------|
+| Home     | GET /api/home                   | Get info for entry point resource        |
+| Help     | GET /api/help                   | Get info for api doc resource            |
+| Blog     | GET /api/blog                   | Get list for blog resource               |
+| Blog     | POST /api/blog                  | Add a blog to list for blog resource     |
+| Blog     | GET /api/blog/{blogId}          | Get info for blog resource               |
+| Blog     | PUT /api/blog/{blogId}          | Replace info for blog resource           |
+| Blog     | DELETE /api/blog/{blogId}       | Delete info for blog resource            |
+| Article  | GET /api/article                | |
+| Article  | POST /api/article               | |
+| Article  | GET /api/article/{articleId}    | |
+| Article  | PUT /api/article/{articleId}    | |
+| Article  | DELETE /api/article/{articleId} | |
+| Comment  | GET /api/comment/{commentId}    | |
+| Comment  | POST /api/comment/{commentId}   | |
+| Comment  | GET /api/comment/{commentId}    | |
+| Comment  | PUT /api/comment/{commentId}    | |
+| Comment  | DELETE /api/comment/{commentId} | |
+
 ### Create an ASP.NET application
 
-### Install the Hydra.NET library
+In a terminal, execute the following to create an ASP.NET project using the Web API template
+```
+dotnet new web --name MyHydraService
+```
+
+Execute the following to change into the project directory to work within the project
+```
+cd MyHydraService
+```
+
+### Install the Hydra.NET library and the JsonLD.Entities library
+
+Execute the following to install the Hydra.NET library (currently only available as a prerelease)
+```
+dotnet add package Hydra.NET --prerelease
+```
+
+Execute the following to install the JsonLd.Entities library
+```
+dotnet add package JsonLd.Entities
+```
+
+### Review folder structure
+
+Execute the following to open the project in VS Code so we can start browsing and editing the source
+```
+code .
+```
+
+Take a look at the folder structure from the VS Code File Explorer. You should see a structure that looks like the following:
+
+| Content                     | Description |
+|-----------------------------|-------------|
+| bin/                        ||                           
+| obj/                        ||
+|Properties                   ||
+|appsettings.Development.json ||
+|appsettings.json             ||
+|ExampleHydraService.csproj   ||
+|Program.cs                   ||
+|Startup.cs                   ||
+
+Create a new folder named 'Resources' where we will place the code for each of the Resources managed by our API
 
 ### Define the Home resource
 
+Under Resources, create a new file called 'Home.cs'
+
+Define a namespace on line 1
+
+Define a class to represent the info for the Home resource
+
+Define a controller to orchestrate the requests for the Home resource
+
+Verify that the code works
+
 ### Define the Help resource
+
+Under Resources, create a new file called 'Help.cs'
+
+Define a namespace on line 1
+
+Define a class to represent the info for the Help resource
+
+Define a controller to orchestrate the requests for the Help resource
+
+Verify that the code works
 
 ### Define the Blog resource
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hydra.NET
 
-Hydra.NET is a simple library for ASP.NET that provides the building blocks necessary for creating hypermedia-driven Web APIs using the [Hydra specification](https://www.hydra-cg.com/spec/latest/core/).
+Hydra.NET is a simple library for ASP.NET that provides the building blocks necessary for creating hypermedia-driven Web APIs with the [Hydra specification](https://www.hydra-cg.com/spec/latest/core/).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # Hydra.NET
 
-Hydra.NET is a simple library that provides building blocks for creating hypermedia-driven web APIs with the [Hydra specification](https://www.hydra-cg.com/spec/latest/core/).
+Hydra.NET is a simple library for .NET that provides building blocks for creating hypermedia-driven web APIs with the [Hydra specification](https://www.hydra-cg.com/spec/latest/core/).
 
-## Usage
+## Quickstart
+
+### Create an ASP.NET application
+
+### Install the Hydra.NET library
+
+### Define the Home resource
+
+### Define the Help resource
+
+### Define the Blog resource
+
+### Define the Article resource
+
+### Define the Comment resource
+
+## General Usage
 
 ### Supported classes
 
@@ -39,7 +55,7 @@ public class Stock
     public double CurrentPrice { get; }
 }
 ```
-### Collections
+### Supported Collections
 
 If you'd like to document a collection for a supported class, you can do so by additionally decorating it with `[SupportedCollection]`.
 
@@ -51,7 +67,7 @@ public class Stock
     // Class code here
 }
 ```
-### Supported operations
+### Supported Operations
 
 Supported operations for a class are designated by decorating methods with `[Operation]`.
 
@@ -71,7 +87,7 @@ public class StocksController
     }
 }
 ```
-### API documentation
+### API Documentation
 
 The `ApiDocumentation` class is the central documentation source for a Hydra web API. Add your supported classes to it via the `AddSupportedClass<T>()` method.
 
@@ -175,7 +191,10 @@ Operations are automatically discovered for their associated types. Given the ab
   ]
 }
 ```
-## Contribute
+
+## Contributing
 
 Hydra.NET is a project I created for use in my personal projects without much expectation that others would be interested. Nevertheless, pull requests and issues are welcome. I've only implemented the parts of the Hydra spec that I've needed, and my understanding of Hydra and JSON-LD is certainly incomplete.
+
+
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This quickstart will show you how to create a basic Hello World ASP.NET Hydra Se
 | ApiDoc     | GET /api/doc   | Get info for Api Doc resource     |
 | Hello      | GET /api/hello | Get info for Hello resource       |
 
+Full code for the finished quickstart is available at [Hydra.NET.Examples/HelloHydraService](https://github.com/lambdakris/Hydra.NET.Examples/tree/main/HelloHydraService)
+
 ### Pre-requisites
 - Git
 - .NET 5 SDK


### PR DESCRIPTION
Hi @mjhoffmeister,

I worked out a Quickstart section for the README that walks the user step by step on how to create a minimal but fully functioning ASP.NET Core Hydra Web API. The Quickstart does reference JsonLd.Entities as well as Newtonsoft.Json, but it does so superficially, without altering/interfering with Hydra.NET's use of System.Text.Json. I also have sample code of the resulting project which I will create a separate PR for. I also couldn't keep from making a few verbiage changes to clarify between Hydra/Hydra.NET types and concepts and general language and framework types and concepts. Hopefully it's not too much, but give it a look and let me know what you think. 

Cheers