### PR TITLE
Make ApiDocumentation context prefix dynamic

### DIFF
--- a/Hydra.NET.UnitTests/ApiDocumentationTest.cs
+++ b/Hydra.NET.UnitTests/ApiDocumentationTest.cs
@@ -16,8 +16,7 @@ namespace Hydra.NET.UnitTests
             string expectedJsonLD = File.ReadAllText(
                 "expected-api-documentation-with-entry-point.jsonld");
 
-            var apiDocumentation = new ApiDocumentation(new Uri("https://api.example.com/doc"));
-            apiDocumentation.Context.TryAddMapping("doc", new Uri("https://api.example.com/doc#"));
+            var apiDocumentation = GetApiDocumentation();
 
             apiDocumentation.EntryPoint = new Uri("https://api.example.com/");
 
@@ -41,8 +40,7 @@ namespace Hydra.NET.UnitTests
             string expectedJsonLD = File.ReadAllText(
                 "expected-api-documentation-with-stock.jsonld");
 
-            var apiDocumentation = new ApiDocumentation(new Uri("https://api.example.com/doc"));
-            apiDocumentation.Context.TryAddMapping("doc", new Uri("https://api.example.com/doc#"));
+            var apiDocumentation = GetApiDocumentation();
 
             apiDocumentation.AddSupportedClass<Stock>();
 
@@ -130,8 +128,7 @@ namespace Hydra.NET.UnitTests
             string expectedJsonLD = File.ReadAllText(
                 "expected-api-documentation-with-stock-shape.jsonld");
 
-            var apiDocumentation = new ApiDocumentation(new Uri("https://api.example.com/doc"));
-            apiDocumentation.Context.TryAddMapping("doc", new Uri("https://api.example.com/doc#"));
+            var apiDocumentation = GetApiDocumentation();
 
             // These categories would come from the API
             var stockCategories = new string[]
@@ -162,5 +159,8 @@ namespace Hydra.NET.UnitTests
 
             Assert.Equal(expectedJsonLD, jsonLD);
         }
+
+        private static ApiDocumentation GetApiDocumentation() =>
+            new(new Uri("https://api.example.com/doc"), "doc");
     }
 }

--- a/Hydra.NET.UnitTests/Stock.cs
+++ b/Hydra.NET.UnitTests/Stock.cs
@@ -3,8 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace Hydra.NET.UnitTests
 {
-    [SupportedClass("doc:Stock", Title = "Stock", Description = "Represents a stock.")]
-    [SupportedCollection("doc:StockCollection", Title = "Stocks", Description = "Stock listing")]
+    [SupportedClass("Stock", Title = "Stock", Description = "Represents a stock.")]
+    [SupportedCollection("StockCollection", Title = "Stocks", Description = "Stock listing")]
     public class Stock
     {
         public Stock(Uri id, string symbol, double currentPrice, string? category = null)
@@ -19,7 +19,7 @@ namespace Hydra.NET.UnitTests
         public Uri Id { get; }
 
         [SupportedProperty(
-            "doc:Stock/symbol",
+            "Stock/symbol",
             Xsd.String,
             Title = "Stock symbol",
             IsWritable = false)]
@@ -27,7 +27,7 @@ namespace Hydra.NET.UnitTests
         public string Symbol { get; }
 
         [SupportedProperty(
-            "doc:Stock/currentPrice",
+            "Stock/currentPrice",
             Xsd.Decimal,
             Title = "Current price",
             Description = "The current price of the stock.")]
@@ -35,7 +35,7 @@ namespace Hydra.NET.UnitTests
         public double CurrentPrice { get; }
 
         [SupportedProperty(
-            "doc:Stock/category",
+            "Stock/category",
             Xsd.String,
             Title = "Category",
             IsRequired = false)]

--- a/Hydra.NET/Hydra.NET.csproj
+++ b/Hydra.NET/Hydra.NET.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>1.0.0-beta9</Version>
+    <Version>1.0.0-beta10</Version>
     <PackageProjectUrl>https://github.com/mjhoffmeister/Hydra.NET</PackageProjectUrl>
     <Authors>Matt Hoffmeister</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Description>Hydra.NET is a simple library that provides building blocks for creating hypermedia-driven web APIs with the Hydra specification.
-</Description>
+    <Description>
+      Hydra.NET is a simple library that provides building blocks for creating hypermedia-driven web
+      APIs with the Hydra specification.
+    </Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Hydra.NET/Property.cs
+++ b/Hydra.NET/Property.cs
@@ -19,7 +19,7 @@ namespace Hydra.NET
         /// </summary>
         /// <param name="id">Id of the property.</param>
         /// <param name="range">Range of the property.</param>
-        internal Property(string id, string range) => (Id, Range) = (new Uri(id), range);
+        internal Property(Uri id, string range) => (Id, Range) = (id, range);
 
         [JsonPropertyName("@id")]
         public Uri? Id { get; set; }

--- a/Hydra.NET/SupportedClass.cs
+++ b/Hydra.NET/SupportedClass.cs
@@ -19,10 +19,12 @@ namespace Hydra.NET
         public SupportedClass() {}
 
         internal SupportedClass(
-            SupportedClassAttribute supportedClassAttribute, NodeShape? nodeShape = null)
+            SupportedClassAttribute supportedClassAttribute,
+            string contextPrefix,
+            NodeShape? nodeShape = null)
         {
             Description = supportedClassAttribute.Description;
-            Id = supportedClassAttribute.Id;
+            Id = new Uri($"{contextPrefix}:{supportedClassAttribute.Id}");
             PropertyShapes = nodeShape?.PropertyShapes;
             Title = supportedClassAttribute.Title;
             Types = nodeShape == null ? new[] { "Class" } : new[] { "Class", "NodeShape" };

--- a/Hydra.NET/SupportedClassAttribute.cs
+++ b/Hydra.NET/SupportedClassAttribute.cs
@@ -12,7 +12,12 @@ namespace Hydra.NET
         /// Includes the class in the API documentation.
         /// </summary>
         /// <param name="id">Id IRI. Relative to the API documentation id.</param>
-        public SupportedClassAttribute(string id) => Id = new Uri(id);
+        public SupportedClassAttribute(string id) => Id = id;
+
+        /// <summary>
+        /// The class's id.
+        /// </summary>
+        public string Id { get; }
 
         /// <summary>
         /// The class's description. Default: <see cref="null"/>.
@@ -23,11 +28,6 @@ namespace Hydra.NET
         /// The class's title. Default: <see cref="null"/>.
         /// </summary>
         public string? Title { get; set; }
-
-        /// <summary>
-        /// The class's id.
-        /// </summary>
-        public Uri Id { get; }
 
     }
 }

--- a/Hydra.NET/SupportedCollection.cs
+++ b/Hydra.NET/SupportedCollection.cs
@@ -14,10 +14,12 @@ namespace Hydra.NET
         public SupportedCollection() { }
 
         internal SupportedCollection(
-            Uri memberId, SupportedCollectionAttribute supportedCollectionAttribute)
+            Uri memberId,
+            SupportedCollectionAttribute supportedCollectionAttribute,
+            string contextPrefix)
         {
             Description = supportedCollectionAttribute.Description;
-            Id = supportedCollectionAttribute.Id;
+            Id = new Uri($"{contextPrefix}:{supportedCollectionAttribute.Id}");
             MemberAssertion = new MemberAssertion(@object: memberId, property: new Uri(Rdf.Type));
             Title = supportedCollectionAttribute.Title;
             Types = new[] { "Collection" };

--- a/Hydra.NET/SupportedCollectionAttribute.cs
+++ b/Hydra.NET/SupportedCollectionAttribute.cs
@@ -11,7 +11,7 @@ namespace Hydra.NET
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]  
     public class SupportedCollectionAttribute : Attribute
     {
-        public SupportedCollectionAttribute(string id) => Id = new Uri(id);
+        public SupportedCollectionAttribute(string id) => Id = id;
 
         /// <summary>
         /// The collection's description.
@@ -21,7 +21,7 @@ namespace Hydra.NET
         /// <summary>
         /// The collection's id.
         /// </summary>
-        public Uri Id { get; }
+        public string Id { get; }
 
         /// <summary>
         /// The collection's title.

--- a/Hydra.NET/SupportedProperty.cs
+++ b/Hydra.NET/SupportedProperty.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Hydra.NET
 {
@@ -14,13 +15,17 @@ namespace Hydra.NET
         /// </summary>
         public SupportedProperty() { }
 
-        internal SupportedProperty(SupportedPropertyAttribute supportedPropertyAttribute)
+        internal SupportedProperty(
+            SupportedPropertyAttribute supportedPropertyAttribute,
+            string contextPrefix)
         {
             Description = supportedPropertyAttribute.Description;
             IsReadable = supportedPropertyAttribute.IsReadable;
             IsRequired = supportedPropertyAttribute.IsRequired;
             IsWritable = supportedPropertyAttribute.IsWritable;
-            Property = supportedPropertyAttribute.Property;
+            Property = new Property(
+                new Uri($"{contextPrefix}:{supportedPropertyAttribute.Id}"),
+                supportedPropertyAttribute.Range);
             Title = supportedPropertyAttribute.Title;
         }
 
@@ -69,9 +74,5 @@ namespace Hydra.NET
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonPropertyName("property")]
         public Property? Property { get; set; }
-
-        
-
-        
     }
 }

--- a/Hydra.NET/SupportedPropertyAttribute.cs
+++ b/Hydra.NET/SupportedPropertyAttribute.cs
@@ -13,13 +13,17 @@ namespace Hydra.NET
         /// </summary>
         /// <param name="id">Id.</param>
         /// <param name="range">Range.</param>
-        public SupportedPropertyAttribute(string id, string range) => 
-            Property = new Property(id, range);
+        public SupportedPropertyAttribute(string id, string range) => (Id, Range) = (id, range);
 
         /// <summary>
         /// The property's description. Default: <see cref="null"/>.
         /// </summary>
         public string? Description { get; set; }
+
+        /// <summary>
+        /// The id of the RDF property.
+        /// </summary>
+        public string Id { get; }
 
         /// <summary>
         /// True if the property is readable; false, otherwise. Default: <see cref="true"/>.
@@ -36,7 +40,10 @@ namespace Hydra.NET
         /// </summary>
         public bool IsWritable { get; set; } = true;
 
-        public Property Property { get; }
+        /// <summary>
+        /// The range of the RDF property.
+        /// </summary>
+        public string Range { get; }
 
         /// <summary>
         /// The property's title. Default: <see cref="null"/>.


### PR DESCRIPTION
Previously, the context prefix for ApiDocumentation was dynamic only
for adding it manually to the ApiDocumentation context. The prefix had
to be hard-coded for supported classes and properties. This change sets
the context prefix dynamically once. It's then applied automatically
throughout the ApiDocumentation.